### PR TITLE
Add initial bot scaffold with Docker support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+DISCORD_TOKEN=your-discord-bot-token
+OPENAI_API_KEY=your-openai-api-key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use official Python image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirement files and install
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+
+# Default command
+CMD ["python", "main.py"]

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+openai:
+  model: gpt-3.5-turbo
+  temperature: 0.7
+
+discord:
+  allowed_user_id: 123456789012345678
+  command_prefix: "!"
+
+reminder:
+  check_interval: 60
+
+database:
+  path: "jun_assistant.db"
+
+timezone: "Asia/Tokyo"
+
+logging:
+  level: INFO
+  file: "junbot.log"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+import os
+import yaml
+from dotenv import load_dotenv
+
+
+def load_config(path="config.yaml"):
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def main():
+    load_dotenv()
+    config = load_config()
+    print("Config loaded:", config)
+    print("Bot token prefix:", os.getenv("DISCORD_TOKEN", "<missing>")[:5])
+    # Placeholder for bot start logic
+    print("Bot starting... (not implemented)")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+discord.py>=2.2.0
+openai>=0.27.0
+python-dotenv>=1.0.0
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- add a simple Python bot entrypoint and config
- supply example `.env` for secrets
- add dependency list
- provide Dockerfile that installs requirements without venv

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_686fac0da5e0832f9e09e6e4c1eb401a