### PR TITLE
Add structured logging setup

### DIFF
--- a/bot/discord_client.py
+++ b/bot/discord_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import logging
 from typing import Any, Dict
 
 import discord
@@ -26,7 +27,7 @@ class JunBot(discord.Client):
         self.bg_task = self.loop.create_task(self._reminder_loop())
 
     async def on_ready(self):
-        print(f"Logged in as {self.user}")
+        logging.getLogger(__name__).info("Logged in as %s", self.user)
 
     async def on_message(self, message: discord.Message):
         if message.author.id != self.allowed_user_id:

--- a/main.py
+++ b/main.py
@@ -1,8 +1,34 @@
 import os
+import logging
+from logging.handlers import RotatingFileHandler
+
 import yaml
 from dotenv import load_dotenv
 
 from bot import DataStore, JunBot
+
+
+def setup_logging(config: dict) -> None:
+    """Configure root logger for both file and console output."""
+    level_str = str(config.get("logging", {}).get("level", "INFO")).upper()
+    log_file = config.get("logging", {}).get("file", "junbot.log")
+
+    level = getattr(logging, level_str, logging.INFO)
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    root_logger.addHandler(console_handler)
+
+    file_handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    file_handler.setFormatter(formatter)
+    root_logger.addHandler(file_handler)
 
 
 def load_config(path="config.yaml"):
@@ -13,6 +39,7 @@ def load_config(path="config.yaml"):
 def main():
     load_dotenv()
     config = load_config()
+    setup_logging(config)
     token = os.getenv("DISCORD_TOKEN")
     if not token:
         raise RuntimeError("DISCORD_TOKEN not set")


### PR DESCRIPTION
## Summary
- set up logging configuration in `main.py`
- add rotating file and console handlers
- call setup_logging when starting the bot
- log `on_ready` event instead of printing

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fc2a55228832f8d303a3b730e2d4a