### PR TITLE
Implement ToDo list NL request

### DIFF
--- a/bot/todo_service.py
+++ b/bot/todo_service.py
@@ -21,6 +21,12 @@ class TodoService:
             "SELECT id, description, due_date, completed FROM tasks ORDER BY id"
         )
 
+    def list_pending_tasks(self) -> List[Tuple[int, str, str]]:
+        """Return only incomplete tasks."""
+        return self.store.fetchall(
+            "SELECT id, description, due_date FROM tasks WHERE completed = 0 ORDER BY id"
+        )
+
     def complete_task(self, task_id: int) -> None:
         self.store.execute(
             "UPDATE tasks SET completed = 1 WHERE id = ?",


### PR DESCRIPTION
## Summary
- extend `TodoService` with `list_pending_tasks`
- support natural language requests for task listing in `JunBot`

## Testing
- `python -m py_compile bot/discord_client.py bot/todo_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd99a82c0832fbb119991dfba34a9