### PR TITLE
Implement reminder add parsing

### DIFF
--- a/bot/discord_client.py
+++ b/bot/discord_client.py
@@ -4,7 +4,8 @@ import asyncio
 import datetime
 import logging
 import re
-from typing import Any, Dict, List
+from zoneinfo import ZoneInfo
+from typing import Any, Dict, List, Tuple
 
 import discord
 
@@ -26,6 +27,7 @@ class JunBot(discord.Client):
         self.todos = TodoService(store)
         self.reminders = ReminderService(store)
         self.schedule = ScheduleService(store)
+        self.tz = ZoneInfo(config.get("timezone", "UTC"))
         self.bg_task = self.loop.create_task(self._reminder_loop())
         # Patterns to detect natural language "add to todo" commands
         self.todo_add_patterns: List[re.Pattern[str]] = [
@@ -33,12 +35,49 @@ class JunBot(discord.Client):
             re.compile(r"(.+?)を?ToDoに追加"),
             re.compile(r"ToDoに(.+?)を追加"),
         ]
+        # Simple patterns for reminder requests (e.g. "明日9時に○○をリマインド")
+        self.reminder_add_patterns: List[re.Pattern[str]] = [
+            re.compile(r"明日(\d{1,2})時(?:([0-9]{1,2})分?)?に(.+?)を?リマインド"),
+            re.compile(
+                r"remind me (?:tomorrow )?at (\d{1,2})(?::(\d{2}))?\s*(am|pm)? to (.+)",
+                re.IGNORECASE,
+            ),
+        ]
 
     def _parse_todo_add(self, text: str) -> str | None:
         for pat in self.todo_add_patterns:
             m = pat.search(text)
             if m:
                 return m.group(1).strip()
+        return None
+
+    def _parse_reminder_add(self, text: str) -> Tuple[str, str] | None:
+        now = datetime.datetime.now(self.tz)
+        for pat in self.reminder_add_patterns:
+            m = pat.search(text)
+            if not m:
+                continue
+            if pat.pattern.startswith("明日"):
+                hour = int(m.group(1))
+                minute = int(m.group(2) or 0)
+                message = m.group(3).strip()
+                remind_date = now.date() + datetime.timedelta(days=1)
+            else:
+                hour = int(m.group(1))
+                minute = int(m.group(2) or 0)
+                ampm = m.group(3)
+                if ampm:
+                    if ampm.lower() == "pm" and hour < 12:
+                        hour += 12
+                    if ampm.lower() == "am" and hour == 12:
+                        hour = 0
+                message = m.group(4).strip()
+                remind_date = now.date() + datetime.timedelta(days=1) if "tomorrow" in pat.pattern else now.date()
+            remind_at = datetime.datetime.combine(
+                remind_date,
+                datetime.time(hour, minute, tzinfo=self.tz),
+            )
+            return message, remind_at.isoformat()
         return None
 
     async def on_ready(self):
@@ -61,8 +100,16 @@ class JunBot(discord.Client):
             if todo_desc:
                 task_id = self.todos.add_task(todo_desc)
                 await message.channel.send(f"Added task #{task_id}")
-            else:
-                await self.handle_chat(message)
+                return
+            reminder = self._parse_reminder_add(message.content)
+            if reminder:
+                msg_text, remind_at = reminder
+                rid = self.reminders.add_reminder(msg_text, remind_at)
+                await message.channel.send(
+                    f"Reminder #{rid} set for {remind_at}"
+                )
+                return
+            await self.handle_chat(message)
 
     async def handle_chat(self, message: discord.Message):
         """Generate a reply using ChatGPT and send it back to the user."""
@@ -95,8 +142,8 @@ class JunBot(discord.Client):
         await self.wait_until_ready()
         interval = int(self.config["reminder"]["check_interval"])
         while not self.is_closed():
-            now = datetime.datetime.now().replace(microsecond=0).isoformat()
-            due = self.reminders.due_reminders(datetime.datetime.now())
+            now = datetime.datetime.now(self.tz).replace(microsecond=0)
+            due = self.reminders.due_reminders(now)
             for rid, msg in due:
                 user = await self.fetch_user(self.allowed_user_id)
                 await user.send(msg)

--- a/bot/discord_client.py
+++ b/bot/discord_client.py
@@ -35,6 +35,12 @@ class JunBot(discord.Client):
             re.compile(r"(.+?)を?ToDoに追加"),
             re.compile(r"ToDoに(.+?)を追加"),
         ]
+        # Patterns for natural language "show todo list" requests
+        self.todo_list_patterns: List[re.Pattern[str]] = [
+            re.compile(r"show (?:my )?(?:todo|task) list", re.IGNORECASE),
+            re.compile(r"ToDoリスト.*(見せて|表示)"),
+            re.compile(r"ToDo一覧"),
+        ]
         # Simple patterns for reminder requests (e.g. "明日9時に○○をリマインド")
         self.reminder_add_patterns: List[re.Pattern[str]] = [
             re.compile(r"明日(\d{1,2})時(?:([0-9]{1,2})分?)?に(.+?)を?リマインド"),
@@ -50,6 +56,9 @@ class JunBot(discord.Client):
             if m:
                 return m.group(1).strip()
         return None
+
+    def _is_todo_list_request(self, text: str) -> bool:
+        return any(p.search(text) for p in self.todo_list_patterns)
 
     def _parse_reminder_add(self, text: str) -> Tuple[str, str] | None:
         now = datetime.datetime.now(self.tz)
@@ -96,6 +105,9 @@ class JunBot(discord.Client):
         if message.content.startswith("/todo"):
             await self.handle_todo_command(message)
         else:
+            if self._is_todo_list_request(message.content):
+                await self._send_todo_list(message.channel)
+                return
             todo_desc = self._parse_todo_add(message.content)
             if todo_desc:
                 task_id = self.todos.add_task(todo_desc)
@@ -137,6 +149,17 @@ class JunBot(discord.Client):
             await message.channel.send("Deleted")
         else:
             await message.channel.send("Invalid /todo command")
+
+    async def _send_todo_list(self, channel: discord.abc.Messageable):
+        tasks = self.todos.list_pending_tasks()
+        if not tasks:
+            await channel.send("(no pending tasks)")
+            return
+        lines = []
+        for tid, desc, due in tasks:
+            due_str = f" (due {due})" if due else ""
+            lines.append(f"{tid}: {desc}{due_str}")
+        await channel.send("\n".join(lines))
 
     async def _reminder_loop(self):
         await self.wait_until_ready()

--- a/bot/discord_client.py
+++ b/bot/discord_client.py
@@ -45,7 +45,7 @@ class JunBot(discord.Client):
         self.reminder_add_patterns: List[re.Pattern[str]] = [
             re.compile(r"明日(\d{1,2})時(?:([0-9]{1,2})分?)?に(.+?)を?リマインド"),
             re.compile(
-                r"remind me (?:tomorrow )?at (\d{1,2})(?::(\d{2}))?\s*(am|pm)? to (.+)",
+                r"remind me (?:(tomorrow) )?at (\d{1,2})(?::(\d{2}))?\s*(am|pm)? to (.+)",
                 re.IGNORECASE,
             ),
         ]
@@ -72,16 +72,17 @@ class JunBot(discord.Client):
                 message = m.group(3).strip()
                 remind_date = now.date() + datetime.timedelta(days=1)
             else:
-                hour = int(m.group(1))
-                minute = int(m.group(2) or 0)
-                ampm = m.group(3)
+                tomorrow = m.group(1)
+                hour = int(m.group(2))
+                minute = int(m.group(3) or 0)
+                ampm = m.group(4)
                 if ampm:
                     if ampm.lower() == "pm" and hour < 12:
                         hour += 12
                     if ampm.lower() == "am" and hour == 12:
                         hour = 0
-                message = m.group(4).strip()
-                remind_date = now.date() + datetime.timedelta(days=1) if "tomorrow" in pat.pattern else now.date()
+                message = m.group(5).strip()
+                remind_date = now.date() + datetime.timedelta(days=1) if tomorrow else now.date()
             remind_at = datetime.datetime.combine(
                 remind_date,
                 datetime.time(hour, minute, tzinfo=self.tz),

--- a/bot/todo_service.py
+++ b/bot/todo_service.py
@@ -21,6 +21,12 @@ class TodoService:
             "SELECT id, description, due_date, completed FROM tasks ORDER BY id"
         )
 
+    def list_pending_tasks(self) -> List[Tuple[int, str, str]]:
+        """Return only incomplete tasks."""
+        return self.store.fetchall(
+            "SELECT id, description, due_date FROM tasks WHERE completed = 0 ORDER BY id"
+        )
+
     def complete_task(self, task_id: int) -> None:
         self.store.execute(
             "UPDATE tasks SET completed = 1 WHERE id = ?",


### PR DESCRIPTION
## Summary
- parse DM text to add reminders from phrases like "明日9時に○○をリマインド"
- handle English "remind me tomorrow at" pattern
- store timezone from config and use it for reminder scheduling

## Testing
- `python -m py_compile bot/discord_client.py bot/reminder_service.py bot/todo_service.py bot/data_store.py openai_client.py main.py bot/llm_client.py bot/schedule_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686fdb2c2360832f96ac99e0598ae070